### PR TITLE
Simplify demo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,50 +27,12 @@ service provider. You decide.
 | `1.19.0-beta.0`    | `20.05.0-alpha17` |                      | [![Build Status](https://dev.azure.com/oneinfra/oneinfra/_apis/build/status/test?branchName=master&jobName=e2e%20tests%20-%201.19.0-beta.0)](https://dev.azure.com/oneinfra/oneinfra/_build?definitionId=3) |
 
 
-## Install
-
-The `oneinfra` installation has several components:
-
-* `oi`: `oneinfra` main CLI tool. This binary allows you to join new
-  worker nodes, generate administrative kubeconfig files...
-
-* `oi-local-hypervisor-set`: allows you to create fake hypervisors
-  running as docker containers. This command is only meant to be used
-  in test environments, never in production.
-
-* `oi-manager` is `oneinfra`'s Kubernetes controller manager. The
-  `oi-manager` is released as a container image and published in the
-  Docker Hub.
-
-* `oi-console` is `oneinfra`'s web console [living in a separate
-  repository](https://github.com/oneinfra/console). The `oi-console`
-  is released as a container image and published in the Docker Hub. It
-  is optional to deploy.
-
-
-### From released binaries
-
-```console
-$ wget -O oi https://github.com/oneinfra/oneinfra/releases/download/20.05.0-alpha17/oi-linux-amd64-20.05.0-alpha17
-$ chmod +x oi
-$ wget -O oi-local-hypervisor-set https://github.com/oneinfra/oneinfra/releases/download/20.05.0-alpha17/oi-local-hypervisor-set-linux-amd64-20.05.0-alpha17
-$ chmod +x oi-local-hypervisor-set
-```
-
-You can now move these binaries to any place in your `$PATH`, or
-execute them with their full path if you prefer.
-
-As an alternative you can [install from source if you
-prefer](docs/install-from-source.md).
-
-
 ## Lightning-quick start
 
 * Requirements
   * Docker
   * `kind`
   * `kubectl`
-  * `oi-local-hypervisor-set`
 
 On a Linux environment, execute:
 

--- a/README.md.in
+++ b/README.md.in
@@ -27,50 +27,12 @@ service provider. You decide.
 | `1.19.0-beta.0`    | `{ONEINFRA_VERSION}` |                      | [![Build Status](https://dev.azure.com/oneinfra/oneinfra/_apis/build/status/test?branchName=master&jobName=e2e%20tests%20-%201.19.0-beta.0)](https://dev.azure.com/oneinfra/oneinfra/_build?definitionId=3) |
 
 
-## Install
-
-The `oneinfra` installation has several components:
-
-* `oi`: `oneinfra` main CLI tool. This binary allows you to join new
-  worker nodes, generate administrative kubeconfig files...
-
-* `oi-local-hypervisor-set`: allows you to create fake hypervisors
-  running as docker containers. This command is only meant to be used
-  in test environments, never in production.
-
-* `oi-manager` is `oneinfra`'s Kubernetes controller manager. The
-  `oi-manager` is released as a container image and published in the
-  Docker Hub.
-
-* `oi-console` is `oneinfra`'s web console [living in a separate
-  repository](https://github.com/oneinfra/console). The `oi-console`
-  is released as a container image and published in the Docker Hub. It
-  is optional to deploy.
-
-
-### From released binaries
-
-```console
-$ wget -O oi https://github.com/oneinfra/oneinfra/releases/download/{ONEINFRA_VERSION}/oi-linux-amd64-{ONEINFRA_VERSION}
-$ chmod +x oi
-$ wget -O oi-local-hypervisor-set https://github.com/oneinfra/oneinfra/releases/download/{ONEINFRA_VERSION}/oi-local-hypervisor-set-linux-amd64-{ONEINFRA_VERSION}
-$ chmod +x oi-local-hypervisor-set
-```
-
-You can now move these binaries to any place in your `$PATH`, or
-execute them with their full path if you prefer.
-
-As an alternative you can [install from source if you
-prefer](docs/install-from-source.md).
-
-
 ## Lightning-quick start
 
 * Requirements
   * Docker
   * `kind`
   * `kubectl`
-  * `oi-local-hypervisor-set`
 
 On a Linux environment, execute:
 

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -16,7 +16,11 @@ if ! which kubectl &> /dev/null; then
 fi
 
 if ! which oi-local-hypervisor-set &> /dev/null; then
-    bail_out "Please, install oi-local-hypervisor-set in order to continue"
+    ONEINFRA_PATH=/tmp/oneinfra-20.05.0-alpha17
+    mkdir -p ${ONEINFRA_PATH}
+    wget -O ${ONEINFRA_PATH}/oi-local-hypervisor-set https://github.com/oneinfra/oneinfra/releases/download/20.05.0-alpha17/oi-local-hypervisor-set-linux-amd64-20.05.0-alpha17
+    chmod +x ${ONEINFRA_PATH}/oi-local-hypervisor-set
+    export PATH=${ONEINFRA_PATH}:${PATH}
 fi
 
 execute_command() {

--- a/scripts/demo.sh.in
+++ b/scripts/demo.sh.in
@@ -16,7 +16,11 @@ if ! which kubectl &> /dev/null; then
 fi
 
 if ! which oi-local-hypervisor-set &> /dev/null; then
-    bail_out "Please, install oi-local-hypervisor-set in order to continue"
+    ONEINFRA_PATH=/tmp/oneinfra-{ONEINFRA_VERSION}
+    mkdir -p ${ONEINFRA_PATH}
+    wget -O ${ONEINFRA_PATH}/oi-local-hypervisor-set https://github.com/oneinfra/oneinfra/releases/download/{ONEINFRA_VERSION}/oi-local-hypervisor-set-linux-amd64-{ONEINFRA_VERSION}
+    chmod +x ${ONEINFRA_PATH}/oi-local-hypervisor-set
+    export PATH=${ONEINFRA_PATH}:${PATH}
 fi
 
 execute_command() {


### PR DESCRIPTION
Simplifies demo instructions by removing the need to download release binary assets, the script will do automatically if they are not found.